### PR TITLE
Update FoundItem.js

### DIFF
--- a/src/components/FoundItem.js
+++ b/src/components/FoundItem.js
@@ -25,7 +25,7 @@ export default class FoundItem extends Component {
             held = <div className='hold'>{mappedHoldMons}</div>
         }
         return(
-            <div className='item-base-display'>
+            <div className='item-base-display' key={item.name}>
                 <div className='item-display' style={{backgroundColor: 'rgb(32, 96, 146)'}}>
                     <img className='item-img' src={item.sprites.default} alt={`sprite of ${name}`} />
                     <div className='name-cost'>


### PR DESCRIPTION
Without a unique key, when you switch pokemon, the dom does not immediately know that there is a change, and it continues to show the old image until the new one is loads (so on slow internet, it will continue to show even though the rest of the text changes).